### PR TITLE
Added Linezolid resistance-associated mutation detection to S. pneumoniae AMR

### DIFF
--- a/R/23SrRNA.R
+++ b/R/23SrRNA.R
@@ -1,5 +1,5 @@
 #' 23S rRNA pipeline for WGS assemblies to determine number of mutated alleles
-#' February 5 2024, Walter Demczuk & Shelley Peterson
+#' October 29, 2025, Walter Demczuk & Shelley Peterson
 #'
 #' @param Org_id Organism to query: GAS, PNEUMO or GONO
 #' @param SampleNo Sample number or "list" or "folder" of sample numbers associated with VCF file(s)

--- a/R/23SrRNA.R
+++ b/R/23SrRNA.R
@@ -1,5 +1,5 @@
 #' 23S rRNA pipeline for WGS assemblies to determine number of mutated alleles
-#' July 3 2024, Walter Demczuk & Shelley Peterson
+#' February 5 2024, Walter Demczuk & Shelley Peterson
 #'
 #' @param Org_id Organism to query: GAS, PNEUMO or GONO
 #' @param SampleNo Sample number or "list" or "folder" of sample numbers associated with VCF file(s)
@@ -21,7 +21,7 @@
 #'
 #' ON GALAXY:
 #'
-#' Alternative_allele_proporition = 0.1
+#' Alternative_allele_proportion = 0.1
 #' min_coverage = 15
 #' min_mean_mapping = 30
 #' run_name = 23S
@@ -37,8 +37,8 @@
 
 #-------------------------------------------------------------------------------
 #  For troubleshooting and debugging
-#Org_id <- "GONO"                   #PNEUMO or GONO
-#SampleNo <- "55555"                #Sample No or "list"  
+#Org_id <- "PNEUMO"                   #PNEUMO or GONO
+#SampleNo <- "list"                #Sample No or "list"  
 #curr_work_dir <- "C:\\WADE\\"
 #-------------------------------------------------------------------------------
 
@@ -112,7 +112,7 @@ rRNA23S_pipeline <- function(Org_id, SampleNo, curr_work_dir) {
       close(con)
       for (i in 1:length(linn))
       {
-        if(str_detect(linn[i], rRNA23S_position1))  #2597 & 2045 for GONO; 2061 for pneumo
+        if(str_detect(linn[i], rRNA23S_position1))  #2045 for GONO; 2061 for pneumo
         {
           vcf_parts <- strsplit(linn[i], ";")
           vcf_parts <- unlist(vcf_parts)
@@ -132,7 +132,7 @@ rRNA23S_pipeline <- function(Org_id, SampleNo, curr_work_dir) {
           A2059G <- 0L
         }
 
-        if(str_detect(linn[i], rRNA23S_position2))  #2597 & 2045 for GONO; 2061 for pneumo
+        if(str_detect(linn[i], rRNA23S_position2))  #2597 for GONO; 2061 for pneumo
         {
           vcf_parts2 <- strsplit(linn[i], ";")
           vcf_parts2 <- unlist(vcf_parts2)
@@ -151,12 +151,41 @@ rRNA23S_pipeline <- function(Org_id, SampleNo, curr_work_dir) {
         {
           C2611T <- 0L
         }
+        
+        if(Org_id == "PNEUMO") #Look for Linezolid Resistance = G2576T (E. coli numbering)
+        {
+          if(str_detect(linn[i], "2578"))  #2578 for Pneumo
+          {
+            vcf_parts2 <- strsplit(linn[i], ";")
+            vcf_parts2 <- unlist(vcf_parts2)
+            DP2_str <- vcf_parts2[8]
+            DP2 <- as.integer(substr(DP2_str, 4, 10))   #total number of reads (depth of reads)
+            AO2_str <- vcf_parts2[6]
+            AO2 <- as.integer(substr(AO2_str, 4, 10))  #alternate observations from reference
+            
+            allele_fraction <- as.integer((AO2/DP2)*100)
+            if(allele_fraction < 14){G2576T <- 0L}
+            if((allele_fraction >= 15) && (allele_fraction <= 34)) {G2576T <- 1L}
+            if((allele_fraction >= 35) && (allele_fraction <= 64)) {G2576T <- 2L}
+            if((allele_fraction >= 65) && (allele_fraction <= 84)) {G2576T <- 3L}
+            if(allele_fraction >= 85) {G2576T <- 4L}
+          }else
+          {
+            G2576T <- 0L
+          }
+        }
       }
     }
 
     cat(CurrSampleNo, "\tAC_2059: ", A2059G, "\tAC_2611: ", C2611T,"\n", sep = "")
 
     SampleProfile.df <- tibble(CurrSampleNo, A2059G, C2611T)
+    
+    if(Org_id == "PNEUMO")
+    {
+      SampleProfile.df$G2576T <- G2576T
+    }
+    
     OutputProfile.df <- rbind(OutputProfile.df, SampleProfile.df)
   
     #Progress Bar
@@ -171,8 +200,14 @@ rRNA23S_pipeline <- function(Org_id, SampleNo, curr_work_dir) {
     cat(paste(" // Estimated time remaining:", remaining), "\n")
   } #>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> End Sample Loop
 
-  header <- c("SampleNo", "A2059G", "C2611T")
-  names(OutputProfile.df) <- header
+  if(Org_id == "GONO")
+  {
+    names(OutputProfile.df) <- c("SampleNo", "A2059G", "C2611T")
+  } else
+  {
+    names(OutputProfile.df) <- c("SampleNo", "A2059G", "C2611T", "G2576T")
+  }
+  
   write.csv(OutputProfile.df, directorylist$outfile, row.names = F)
 
   elapsed <- format(Sys.time() - start_time)

--- a/R/EMM.R
+++ b/R/EMM.R
@@ -161,18 +161,20 @@ EMM_pipeline <- function(Org_id, SampleNo, curr_work_dir){
         
         emmNumber <- sub("emm","", emmType)
         contigsline <- grep(paste0(">EMM", emmNumber), blastoutput2)
-                if(length(contigsline) > 0)
+        if(length(contigsline) > 0)
         {
           blastoutput2 <- blastoutput2[contigsline[1]:contigsline[2]]   
           QueryLine <- grep("Query ", blastoutput2, value = TRUE)
           QueryLine <- QueryLine[1:3]
           emmseq <- gsub("[^AaCcTtGgN-]", "", paste(QueryLine, collapse = ""))
-        
+          
           sink(dna_file, split=FALSE, append = TRUE)
           cat(">", "emm", "_", CurrSampleNo, "_", emmType,"\n",
               emmseq, "\n", sep ="")
           sink()
         }
+
+        
       }#======================================================================== End found EMM
     }#~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ End look for EMM
 

--- a/R/LabwareUpload_PNEUMO_AMR.R
+++ b/R/LabwareUpload_PNEUMO_AMR.R
@@ -1,5 +1,5 @@
 #' Labware Upload Formatter for PNEUMO AMR
-#' August 28 2025, Walter Demczuk & Shelley Peterson
+#' October 29 2025, Walter Demczuk & Shelley Peterson
 #' Run AMR first, then run the 23S allele counts,
 #' Then run this analysis to combine data from AMR, 23S rRNA
 #' to prepare full amr profile to upload to LabWare.
@@ -53,7 +53,7 @@ labware_pneumo_amr <- function(Org_id, curr_work_dir) {
     {
       sample_data.df <- tibble(lw_CurrSampleNo, lw_pbp1a = "Sample_Err", 
                                lw_pbp2b = "Sample_Err", lw_pbp2x = "Sample_Err",
-                               lw_23S_A2059G = "Sample_Err", lw_23S_C2611T <- "Sample_Err",
+                               lw_23S_A2059G = "Sample_Err", lw_23S_C2611T = "Sample_Err",
                                lw_ermB = "Sample_Err", lw_ermTR = "Sample_Err", 
                                lw_mefAE = "Sample_Err", lw_folA = "Sample_Err", 
                                lw_folP = "Sample_Err", lw_gyrA = "Sample_Err", 
@@ -109,6 +109,9 @@ labware_pneumo_amr <- function(Org_id, curr_work_dir) {
       rRNA23S$molec_profile_23S <- ifelse((is.na(rRNA23S$lw_23S_prof) & rRNA23S$lw_23S_C2611T > 0),
                                            paste0(rRNA23S$molec_profile_23S, "23S rRNA C2611T: ",
                                                   rRNA23S$lw_23S_C2611T, "/4"), NA)
+      rRNA23S$molec_profile_23S <- ifelse((is.na(rRNA23S$lw_23S_prof) & Combined_Output.df[m, "G2576T"] > 0),
+                                          paste0(rRNA23S$molec_profile_23S, "23S rRNA G2576T: ",
+                                                 Combined_Output.df[m, "G2576T"], "/4"), NA)
       rRNA23S$molec_profile_23S <- sub("NA", "", rRNA23S$molec_profile_23S)
       rRNA23S$lw_23S_prof[is.na(rRNA23S$lw_23S_prof)] <- rRNA23S$molec_profile_23S
 
@@ -152,7 +155,7 @@ labware_pneumo_amr <- function(Org_id, curr_work_dir) {
       ##### cat #####
       cat <- posneg_gene(Combined_Output.df, "cat", m)
 
-      # -------------------- Vancomycin - Not included in LW export, but is included in molec_profile
+      # ---------- Vancomycin - Not included in LW export, but is included in molec_profile
   
       ##### vanA #####
       vanA <- posneg_gene(Combined_Output.df, "vanA", m)
@@ -171,6 +174,14 @@ labware_pneumo_amr <- function(Org_id, curr_work_dir) {
 
       ##### vanG #####
       vanG <- posneg_gene(Combined_Output.df, "vanG", m)
+      
+      # ---------- Linezolid - Not included in LW export, but it is included in molec_profile
+      ##### rplD #####
+      rplD <- allele4SNPs(Combined_Output.df, "rplD", "rplD", "motifs", "PWRQ", "Q67", "R72", "QKGT", m)
+      rplD$molec_profile_rplD <- NA
+      rplD$molec_profile_rplD[rplD$lw_rplD_PWRQ == "P--Q"] <- "rplD P--Q"
+      rplD$molec_profile_rplD[rplD$lw_rplD_Q67 == "R" & rplD$lw_rplD_R72 == "G"] <- "rplD Q67R/R72G"
+      rplD$molec_profile_rplD[rplD$lw_rplD_QKGT == "Q--T"] <- "rplD Q--T"
 
       ######################## Now put them all together #######################
       molec_profile <- paste(ermB$molec_profile_ermB, ermTR$molec_profile_ermTR,
@@ -182,7 +193,8 @@ labware_pneumo_amr <- function(Org_id, curr_work_dir) {
                              gyrA$molec_profile_gyrA, parC$molec_profile_parC,
                              vanA$molec_profile_vanA, vanB$molec_profile_vanB,
                              vanC$molec_profile_vanC, vanD$molec_profile_vanD,
-                             vanE$molec_profile_vanE, vanG$molec_profile_vanG, sep = "; ")
+                             vanE$molec_profile_vanE, vanG$molec_profile_vanG, 
+                             rplD$molec_profile_rplD, sep = "; ")
       molec_profile <- gsub("NA; ", "", molec_profile)
       molec_profile <- sub("; NA", "", molec_profile)
 


### PR DESCRIPTION
S. pneumoniae AMR - added linezolid resistance markers to the list of mutations to look for - these will be like vancomycin and only show up in the molecular markers profile if found, but not in the AMR profile. 

Molecular markers included:
- 23S rRNA G2576T (G2578T in SPN numbering)
- rplD 64PWRQ67 -> P—Q
- rplD Q67R and R72G <- these will only be mentioned in molec_markers if both are present
- rplD 67QKGT70 -> Q—T